### PR TITLE
Ft failed checks tab #151946831

### DIFF
--- a/hc/front/tests/test_my_failed_checks.py
+++ b/hc/front/tests/test_my_failed_checks.py
@@ -1,0 +1,28 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta as td
+from django.utils import timezone
+
+
+class MyChecksTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(MyChecksTestCase, self).setUp()
+        self.check = Check(user=self.alice, name="Alice Was Here")
+        self.check.save()
+
+    def test_it_works(self):
+        for email in ("alice@example.org", "bob@example.org"):
+            self.client.login(username=email, password="password")
+            self.check.last_ping = timezone.now() - td(days=3)
+            self.check.status = "up"
+            self.check.save()
+            r = self.client.get("/checks_failed/")
+            self.assertContains(r, "Alice Was Here", status_code=200)
+
+    def test_it_does_not_show_checks_that_have_not_failed(self):
+        for email in ("alice@example.org", "bob@example.org"):
+            self.client.login(username=email, password="password")
+            r = self.client.get("/checks_failed/")
+            self.assertContains(r, "No Failed checks", status_code=200)
+

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -31,6 +31,7 @@ channel_urls = [
 urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
+    url(r'^failed_checks', views.my_failed_checks, name="failed_checks"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -31,7 +31,7 @@ channel_urls = [
 urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
-    url(r'^failed_checks', views.my_failed_checks, name="failed_checks"),
+    url(r'^checks_failed/', views.my_failed_checks, name="failed_checks"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -59,6 +59,35 @@ def my_checks(request):
 
     return render(request, "front/my_checks.html", ctx)
 
+@login_required
+def my_failed_checks(request):
+    q = Check.objects.filter(user=request.team.user).order_by("created")
+    checks = list(q)
+
+    counter = Counter()
+    down_tags, grace_tags = set(), set()
+    for check in checks:
+        status = check.get_status()
+        for tag in check.tags_list():
+            if tag == "":
+                continue
+
+            counter[tag] += 1
+
+            if status == "down":
+                down_tags.add(tag)
+
+    ctx = {
+        "page": "checks_failed",
+        "checks": checks,
+        "now": timezone.now(),
+        "tags": counter.most_common(),
+        "down_tags": down_tags,
+        "ping_endpoint": settings.PING_ENDPOINT
+    }
+
+    return render(request, "front/my_checks.html", ctx)
+
 
 def _welcome_check(request):
     check = None

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -47,6 +47,7 @@ def my_checks(request):
             elif check.in_grace_period():
                 grace_tags.add(tag)
 
+
     ctx = {
         "page": "checks",
         "checks": checks,
@@ -65,7 +66,7 @@ def my_failed_checks(request):
     checks = list(q)
 
     counter = Counter()
-    down_tags, grace_tags = set(), set()
+    down_tags= set(),
     for check in checks:
         status = check.get_status()
         for tag in check.tags_list():
@@ -86,7 +87,7 @@ def my_failed_checks(request):
         "ping_endpoint": settings.PING_ENDPOINT
     }
 
-    return render(request, "front/my_checks.html", ctx)
+    return render(request, "front/my_failed_checks.html", ctx)
 
 
 def _welcome_check(request):

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -29,7 +29,7 @@ def pairwise(iterable):
 
 @login_required
 def my_checks(request):
-    q = Check.objects.filter(user=request.team.user).order_by("created")
+    q = Check.objects.filter(user=request.team.user ).order_by("created")
     checks = list(q)
 
     counter = Counter()
@@ -62,7 +62,7 @@ def my_checks(request):
 
 @login_required
 def my_failed_checks(request):
-    q = Check.objects.filter(user=request.team.user).order_by("created")
+    q = Check.objects.filter(user=request.team.user, status="down").order_by("created")
     checks = list(q)
 
     counter = Counter()

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -29,7 +29,7 @@ def pairwise(iterable):
 
 @login_required
 def my_checks(request):
-    q = Check.objects.filter(user=request.team.user ).order_by("created")
+    q = Check.objects.filter(user=request.team.user).order_by("created")
     checks = list(q)
 
     counter = Counter()

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -62,28 +62,19 @@ def my_checks(request):
 
 @login_required
 def my_failed_checks(request):
-    q = Check.objects.filter(user=request.team.user, status="down").order_by("created")
+    q = Check.objects.filter(user=request.team.user).order_by("created").all()
     checks = list(q)
 
-    counter = Counter()
-    down_tags= set(),
+    unresolved = []
     for check in checks:
         status = check.get_status()
-        for tag in check.tags_list():
-            if tag == "":
-                continue
-
-            counter[tag] += 1
-
-            if status == "down":
-                down_tags.add(tag)
+        if status == "down":
+            unresolved.append(check)
 
     ctx = {
         "page": "checks_failed",
-        "checks": checks,
+        "checks": unresolved,
         "now": timezone.now(),
-        "tags": counter.most_common(),
-        "down_tags": down_tags,
         "ping_endpoint": settings.PING_ENDPOINT
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,9 @@
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>
+                    <li>
+                        <a>Unresolved</a>
+                    </li>
 
                 {% endif %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,7 +81,7 @@
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>
                     <li{% if page == 'checks_failed' %} class ="active"{% endif %}>
-                        <a href="{% url 'hc-checks' %}">Unresolved</a>
+                        <a href="{% url 'failed_checks' %}">Unresolved</a>
                     
                     </li>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,8 +80,9 @@
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>
-                    <li>
-                        <a>Unresolved</a>
+                    <li{% if page == 'checks_failed' %} class ="active"{% endif %}>
+                        <a href="{% url 'hc-checks' %}">Unresolved</a>
+                    
                     </li>
 
                 {% endif %}

--- a/templates/front/my_failed_checks.html
+++ b/templates/front/my_failed_checks.html
@@ -1,0 +1,279 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}My Checks - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Failed Checks
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_checks_mobile.html" %}
+        {% include "front/my_checks_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">No Failed checks</div>
+    {% endif %}
+    </div>
+</div>
+
+<div id="update-name-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-name-form" class="form-horizontal" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="update-timeout-title">Name and Tags</h4>
+                </div>
+                <div class="modal-body">
+                        <div class="form-group">
+                            <label for="update-name-input" class="col-sm-2 control-label">
+                                Name
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-name-input"
+                                    name="name"
+                                    type="text"
+                                    value="---"
+                                    placeholder="unnamed"
+                                    class="input-name form-control" />
+
+                                <span class="help-block">
+                                    Give this check a human-friendly name,
+                                    so you can easily recognize it later.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="update-tags-input" class="col-sm-2 control-label">
+                                Tags
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-tags-input"
+                                    name="tags"
+                                    type="text"
+                                    value=""
+                                    placeholder="production www"
+                                    class="form-control" />
+
+                                <span class="help-block">
+                                    Optionally, assign tags for easy filtering.
+                                    Separate multiple tags with spaces.
+                                </span>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-timeout-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-timeout-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="timeout" id="update-timeout-timeout" />
+            <input type="hidden" name="grace" id="update-timeout-grace" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Expected time between pings.">
+                            Period
+                        </span>
+                        <span
+                            id="period-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="When check is late, how much time to wait until alert is sent">
+                            Grace Time
+                        </span>
+                        <span
+                            id="grace-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between pings.
+                        </p>
+                        <p>
+                            <span>Grace Time</span>
+                            When a check is late, how much time to wait until alert is sent.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="remove-check-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="remove-check-form" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="remove-check-title">Remove Check <span class="remove-check-name"></span></h4>
+                </div>
+                <div class="modal-body">
+                    <p>You are about to remove check
+                        <strong class="remove-check-name">---</strong>.
+                    </p>
+                    <p>Once it's gone there is no "undo" and you cannot get
+                    the old ping URL back.</p>
+                    <p>Are you sure?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Remove</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<form id="pause-form" method="post">
+    {% csrf_token %}
+</form>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
**What does this PR do?**

Displays to the user failed jobs

**Description of Task to be completed?**

A user can now be able to view the jobs that have failed and they have been notified about on the unresolved tab in the dashboard

**How should this be manually tested?**

After cloning the repo, cd into healthchecks-a-team and run command ./manage.py runserver. Then once you log in, create a check. Go to the unresolved tab to see if any of your checks has failed

**Any background context you want to provide?**

Initially, once a user job fails he is notified through the email but once he logs in to the dashboard he cannot see only the failed jobs that he had been notified about

**What are the relevant pivotal tracker stories?**

#151946831

