### PR TITLE
[Bug]remove email credentials from settings

### DIFF
--- a/hc/settings.py
+++ b/hc/settings.py
@@ -147,13 +147,7 @@ STATICFILES_FINDERS = (
 )
 COMPRESS_OFFLINE = True
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = 'smtp.googlemail.com'
-EMAIL_PORT = 465
-EMAIL_HOST_USER = "andelatestmail@gmail.com"
-EMAIL_HOST_PASSWORD = "andelatestmail1"
-EMAIL_USE_TLS = False
-EMAIL_USE_SSL = True
+
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None


### PR DESCRIPTION
#### What does this PR do?
Removes the email credentials  from the main settings file
#### Description of Task to be completed?
Email credentials should be removed from the main settings file and added to local settings file
#### How should this be manually tested?
Add email credentials to your local settings as shown below:

EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
EMAIL_HOST = 'your-email-host-here'
EMAIL_PORT = 'email-port-number'
EMAIL_HOST_USER = "your-email"
EMAIL_HOST_PASSWORD = "email-password"
EMAIL_USE_TLS = False
EMAIL_USE_SSL = True

Run the command './manage.py sendalerts' to see if the email is being sent to the user
#### Any background context you want to provide?
Initially, the email credentials were in the main settings file which made them public to everybody in git
#### What are the relevant pivotal tracker stories?
#152594219
